### PR TITLE
Fix: Javascript node error logs

### DIFF
--- a/packages/noodl-runtime/src/nodes/std-library/simplejavascript.js
+++ b/packages/noodl-runtime/src/nodes/std-library/simplejavascript.js
@@ -1,4 +1,5 @@
 const JavascriptNodeParser = require('../../javascriptnodeparser');
+const { logJavaScriptNodeError } = require('../../utils');
 
 const SimpleJavascriptNode = {
   name: 'JavaScriptFunction',
@@ -139,11 +140,8 @@ const SimpleJavascriptNode = {
           JavascriptNodeParser.getComponentScopeForNode(this)
         ]);
       } catch (e) {
-        console.log(
-          'Error in JS node run code.',
-          Object.getPrototypeOf(e).constructor.name + ': ' + e.message,
-          e.stack
-        );
+        logJavaScriptNodeError(e);
+
         if (this.context.editorConnection && this.context.isWarningTypeEnabled('javascriptExecution')) {
           this.context.editorConnection.sendWarning(
             this.nodeScope.componentOwner.name,

--- a/packages/noodl-runtime/src/utils.js
+++ b/packages/noodl-runtime/src/utils.js
@@ -12,6 +12,24 @@ function getAbsoluteUrl(_url) {
   return (Noodl.baseUrl || '/') + url;
 }
 
+/**
+ * Log an error thrown by the JavaScript nodes.
+ *
+ * @param {any} error 
+ */
+function logJavaScriptNodeError(error) {
+  if (typeof error === 'string') {
+    console.log('Error in JS node run code.', error);
+  } else {
+    console.log(
+      'Error in JS node run code.',
+      Object.getPrototypeOf(error).constructor.name + ': ' + error.message,
+      error.stack
+    );
+  }
+}
+
 module.exports = {
-  getAbsoluteUrl
+  getAbsoluteUrl,
+  logJavaScriptNodeError
 };

--- a/packages/noodl-viewer-react/src/nodes/std-library/javascript.js
+++ b/packages/noodl-viewer-react/src/nodes/std-library/javascript.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const Node = require('@noodl/runtime').Node,
-  JavascriptNodeParser = require('@noodl/runtime/src/javascriptnodeparser');
-
+const Node = require('@noodl/runtime').Node;
+const JavascriptNodeParser = require('@noodl/runtime/src/javascriptnodeparser');
+const { logJavaScriptNodeError } = require('@noodl/runtime/src/utils');
 const guid = require('../../guid');
 
 /*const defaultCode = "define({\n"+
@@ -372,7 +372,8 @@ var Javascript = {
           internal.changedInputs
         );
       } catch (e) {
-        console.log('Error in JS node run code.', Object.getPrototypeOf(e).constructor.name + ': ' + e.message);
+        logJavaScriptNodeError(e);
+
         if (this.context.editorConnection && this.context.isWarningTypeEnabled('javascriptExecution')) {
           this.context.editorConnection.sendWarning(this.nodeScope.componentOwner.name, this.id, 'js-run-waring', {
             showGlobally: true,


### PR DESCRIPTION
In some cases the error is a string, and when logging it will write "undefined" into the console instead of providing a useful error message.

When calling this JS code:
```js
await Noodl.Records.query(
    "MyClass",
    {
        status: { equalTo: "ACTIVE" },
        status2: { equalTo: "ACTIVE" },
    }
);
```

Before:
```
Error in JS node run code. String: undefined undefined
```

After:
```
Error in JS node run code. Filter must only have one key found status,status2
```