### PR TITLE
feat: Editor Preview, patch "window.open" to navigate in same view

### DIFF
--- a/packages/noodl-editor/src/editor/src/views/VisualCanvas/CanvasView.ts
+++ b/packages/noodl-editor/src/editor/src/views/VisualCanvas/CanvasView.ts
@@ -96,6 +96,12 @@ export class CanvasView extends View {
             });
           }
         });
+
+        // Patch to open the next window in the same webview.
+        // Since we don't support multiple webviews.
+        window.open = function (url) {
+          window.location.href = url;
+        }
       `;
 
       webview.executeJavaScript(code);


### PR DESCRIPTION
Allows the [Navigate To Path](https://docs.fluxscape.io/nodes/navigation/navigate-to-path/) node with "Open in new tab" to be used in the Editor Preview.