### PR TITLE
feat: When deploying Cloud Functions include project info

### DIFF
--- a/packages/noodl-editor/src/editor/src/utils/compilation/passes/deploy-cloud-functions.ts
+++ b/packages/noodl-editor/src/editor/src/utils/compilation/passes/deploy-cloud-functions.ts
@@ -74,7 +74,13 @@ export const deployCloudFunctionBuildScript: BuildScript = {
               'X-Parse-Application-Id': environment.appId,
               'X-Parse-Master-Key': environment.masterKey
             },
-            body: JSON.stringify({ deploy: json, runtime: manifest.version })
+            body: JSON.stringify({
+              // Project ID, let the server know about which project is pushing changes.
+              projectId: context.project.id,
+              projectName: context.project.name,
+              deploy: json,
+              runtime: manifest.version
+            })
           });
 
           // NOTE: Expecting that we always get a JSON response


### PR DESCRIPTION
This is required to make sure that the Cloud Service can handle calling Cloud Functions externally when there are multiple frontends.
