### PR TITLE
feat: Improve the Noodl.Records.query typings API

### DIFF
--- a/packages/noodl-runtime/src/nodes/std-library/data/setdbmodelpropertiesnode.js
+++ b/packages/noodl-runtime/src/nodes/std-library/data/setdbmodelpropertiesnode.js
@@ -75,12 +75,12 @@ var SetDbModelPropertiedNodeDefinition = {
             _this.setError('Missing Record Id');
             return;
           }
-          var model = internal.model;
-
-          for (var i in internal.inputValues) {
-            model.set(i, internal.inputValues[i], { resolve: true });
+          
+          const model = internal.model;
+          for (const key in internal.inputValues) {
+            model.set(key, internal.inputValues[key], { resolve: true });
           }
-
+          
           CloudStore.forScope(_this.nodeScope.modelScope).save({
             collection: internal.collectionId,
             objectId: model.getId(), // Get the objectId part of the model id

--- a/packages/noodl-viewer-cloud/static/viewer/global.d.ts.keep
+++ b/packages/noodl-viewer-cloud/static/viewer/global.d.ts.keep
@@ -74,6 +74,59 @@ declare namespace Noodl {
    */
   const Object: any;
 
+  type RecordQuery<T> =
+    {
+      lessThan: T
+    } |
+    {
+      lessThanOrEqualTo: T
+    } |
+    {
+      greaterThan: T
+    } |
+    {
+      greaterThanOrEqualTo: T
+    } |
+    {
+      equalTo: T
+    } |
+    {
+      notEqualTo: T
+    } |
+    {
+      containedIn: T
+    } |
+    {
+      notContainedIn : T
+    } |
+    {
+      exists: T
+    } |
+    {
+      matchesRegex: T
+    } |
+    {
+      text: T
+    } |
+    {
+      idEqualTo: T
+    } |
+    {
+      idContainedIn: T
+    } |
+    {
+      pointsTo: T
+    } |
+    {
+      relatedTo: T
+    };
+
+  type RecordQueryField<T> = T extends RecordQuery<any> ?
+    { [K in keyof T]: { [P in K]: T[P] } & Partial<Record<Exclude<keyof T, K>, never>> }[keyof T]
+    : never;
+
+  type RecordSortKey<T extends string> = (`${T}` | `-${T}`)[];
+
   interface RecordsApi {
     /**
      * This is an async function that will query the database using the query
@@ -115,15 +168,17 @@ declare namespace Noodl {
      *  })
      * ```
      */
-    query(
-      className: RecordClassName,
-      query?: any,
+    query<TClassName extends RecordClassName>(
+      className: TClassName,
+      query?:
+        RecordQueryField<{ [K in keyof DatabaseSchema[TClassName]]: RecordQuery<any> }> |
+        { and: RecordQueryField<{ [K in keyof DatabaseSchema[TClassName]]: RecordQuery<any> }>[] },
       options?: {
         limit?: number;
         skip?: number;
-        sort?: string[];
-        include?: any;
-        select?: any;
+        sort?: string | RecordSortKey<keyof DatabaseSchema[TClassName]>;
+        include?: string | (keyof DatabaseSchema[TClassName])[];
+        select?: string | (keyof DatabaseSchema[TClassName])[];
       }
     ): Promise<any>;
 

--- a/packages/noodl-viewer-react/static/viewer/global.d.ts.keep
+++ b/packages/noodl-viewer-react/static/viewer/global.d.ts.keep
@@ -131,6 +131,59 @@ declare namespace Noodl {
    */
   const Events: EventsApi;
 
+  type RecordQuery<T> =
+    {
+      lessThan: T
+    } |
+    {
+      lessThanOrEqualTo: T
+    } |
+    {
+      greaterThan: T
+    } |
+    {
+      greaterThanOrEqualTo: T
+    } |
+    {
+      equalTo: T
+    } |
+    {
+      notEqualTo: T
+    } |
+    {
+      containedIn: T
+    } |
+    {
+      notContainedIn : T
+    } |
+    {
+      exists: T
+    } |
+    {
+      matchesRegex: T
+    } |
+    {
+      text: T
+    } |
+    {
+      idEqualTo: T
+    } |
+    {
+      idContainedIn: T
+    } |
+    {
+      pointsTo: T
+    } |
+    {
+      relatedTo: T
+    };
+
+  type RecordQueryField<T> = T extends RecordQuery<any> ?
+    { [K in keyof T]: { [P in K]: T[P] } & Partial<Record<Exclude<keyof T, K>, never>> }[keyof T]
+    : never;
+
+  type RecordSortKey<T extends string> = (`${T}` | `-${T}`)[];
+
   interface RecordsApi {
     /**
      * This is an async function that will query the database using the query
@@ -172,15 +225,17 @@ declare namespace Noodl {
      *  })
      * ```
      */
-    query(
-      className: RecordClassName,
-      query?: any,
+    query<TClassName extends RecordClassName>(
+      className: TClassName,
+      query?:
+        RecordQueryField<{ [K in keyof DatabaseSchema[TClassName]]: RecordQuery<any> }> |
+        { and: RecordQueryField<{ [K in keyof DatabaseSchema[TClassName]]: RecordQuery<any> }>[] },
       options?: {
         limit?: number;
         skip?: number;
-        sort?: string[];
-        include?: any;
-        select?: any;
+        sort?: string | RecordSortKey<keyof DatabaseSchema[TClassName]>;
+        include?: string | (keyof DatabaseSchema[TClassName])[];
+        select?: string | (keyof DatabaseSchema[TClassName])[];
       }
     ): Promise<any>;
 


### PR DESCRIPTION
Improve the TypeScript typings for the code editor when using the Records query API. Quite nice to be able to write the queries faster without having to leave the code editor, there is a lot more improvements that can be done here.

![image](https://github.com/fluxscape/fluxscape/assets/1263211/a16f947b-b90a-43a1-a9c6-ae107fa7e061)
