### PR TITLE
fix(runtime): Column node added a div with empty Repeater

### DIFF
--- a/packages/noodl-viewer-react/src/components/visual/Columns/Columns.tsx
+++ b/packages/noodl-viewer-react/src/components/visual/Columns/Columns.tsx
@@ -117,7 +117,10 @@ export function Columns(props: ColumnsProps) {
 
   // ForEachCompoent breaks the layout but is needed to send onMount/onUnmount
   if (!Array.isArray(props.children)) {
-    children = [props.children];
+    // @ts-expect-error props.children.type is any
+    if (props.children.type !== ForEachComponent) {
+      children = [props.children]
+    }
   } else {
     children = props.children.filter((child) => child.type !== ForEachComponent);
     forEachComponent = props.children.find((child) => child.type === ForEachComponent);


### PR DESCRIPTION
When the Column node only had an empty Repeater child, there was an empty HTML element.

This will add an empty DIV element, that have no effect.
![image](https://github.com/fluxscape/fluxscape/assets/1263211/d1601f7e-7b8b-4db4-b20b-b140212734da)
