### PR TITLE
feat(runtime): Add Image node output "On Error" signal

### DIFF
--- a/packages/noodl-viewer-react/src/nodes/visual/image.js
+++ b/packages/noodl-viewer-react/src/nodes/visual/image.js
@@ -125,6 +125,12 @@ const ImageNode = {
       propPath: 'dom',
       type: 'signal',
       group: 'Events'
+    },
+    onError: {
+      displayName: 'On Error',
+      propPath: 'dom',
+      type: 'signal',
+      group: 'Events'
     }
   }
 };


### PR DESCRIPTION
"On Error" is triggered when the image is not loading correctly, making it possible to hide the Image node or show a placeholder instead.