### PR TITLE
feat(runtime): Add default label to String Format node

### DIFF
--- a/packages/noodl-runtime/src/nodes/std-library/stringformat.js
+++ b/packages/noodl-runtime/src/nodes/std-library/stringformat.js
@@ -2,6 +2,8 @@ const StringFormatDefinition = {
   name: 'String Format',
   docs: 'https://docs.noodl.net/nodes/string-manipulation/string-format',
   category: 'String Manipulation',
+  usePortAsLabel: 'format',
+  portLabelTruncationMode: 'length',
   initialize() {
     const internal = this._internal;
     internal.format = '';


### PR DESCRIPTION
Update the String Format node default label to show the format, like how the other nodes work.

![image](https://github.com/fluxscape/fluxscape/assets/1263211/415715ea-1601-4b2c-8f2f-1be6b3ac4589)
