### PR TITLE
fix(runtime): Base URL with Script node external file

### DIFF
--- a/packages/noodl-runtime/src/utils.js
+++ b/packages/noodl-runtime/src/utils.js
@@ -1,21 +1,20 @@
 //this just assumes the base url is '/' always
 function getAbsoluteUrl(_url) {
-
   //convert to string in case the _url is a Cloud File (which is an object with a custom toString())
   const url = String(_url);
 
   //only add a the base url if this is a local URL (e.g. not a https url or  base64 string)
-  if (!url || url[0] === "/" || url.includes("://") || url.startsWith('data:')) {
+  if (!url || url[0] === '/' || url.includes('://') || url.startsWith('data:')) {
     return url;
   }
 
-  return (Noodl.baseUrl || '/') + url;
+  return (Noodl.Env['BaseUrl'] || '/') + url;
 }
 
 /**
  * Log an error thrown by the JavaScript nodes.
  *
- * @param {any} error 
+ * @param {any} error
  */
 function logJavaScriptNodeError(error) {
   if (typeof error === 'string') {


### PR DESCRIPTION
With this change I believe parts like this could be removed, as they should also use the `getAbsoluteUrl`.

https://github.com/fluxscape/fluxscape/blob/0668d0e928a01fce5b24af1e3d794d9d6d622844/packages/noodl-viewer-react/src/components/visual/Image/Image.tsx#L26-L32