### PR TITLE
feat(runtime): Add capture attribute on Open File Picker node

### DIFF
--- a/packages/noodl-viewer-react/src/nodes/std-library/openfilepicker.js
+++ b/packages/noodl-viewer-react/src/nodes/std-library/openfilepicker.js
@@ -43,6 +43,10 @@ const OpenFilePicker = {
 
         input.accept = this._internal.acceptedFileTypes;
 
+        if (this._internal.capture) {
+          input.capture = this._internal.capture;
+        }
+
         input.onchange = onChange;
         input.click();
       }
@@ -53,6 +57,14 @@ const OpenFilePicker = {
       displayName: 'Accepted file types',
       set(value) {
         this._internal.acceptedFileTypes = value;
+      }
+    },
+    capture: {
+      group: 'General',
+      type: 'string',
+      displayName: 'Capture',
+      set(value) {
+        this._internal.capture = value;
       }
     }
   },


### PR DESCRIPTION
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#capture
- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/capture

> Note: capture was previously a Boolean attribute which, if present, requested that the device's media capture device(s) such as camera or microphone be used instead of requesting a file input.

In this PR, `capture` is added as a string. `capture` as a string has limited support, but can still be used as truthy and falsely.