### PR TITLE
feat(viewer-react): Add Target Page input to "Push Component To Stack"

### DIFF
--- a/packages/noodl-viewer-react/src/nodes/navigation/navigate.js
+++ b/packages/noodl-viewer-react/src/nodes/navigation/navigate.js
@@ -192,8 +192,7 @@ function setup(context, graphModel) {
               enums: pages.map((p) => ({
                 label: p.label,
                 value: p.id
-              })),
-              allowEditOnly: true
+              }))
             },
             group: 'General',
             displayName: 'Target Page',


### PR DESCRIPTION
Allowing a dynamic "Push Component To Stack" Target Page input, using either the internal Page ID by the Component Stack or **the Component label inside the Component Stack**.

![image](https://github.com/user-attachments/assets/cc9fd0a8-309c-46e6-b320-4ad671f72e92)
