### PR TITLE
feat(runtime): Add "className" option support to "relatedTo"

### DIFF
--- a/packages/noodl-runtime/src/api/queryutils.js
+++ b/packages/noodl-runtime/src/api/queryutils.js
@@ -203,7 +203,7 @@ function convertFilterOp(filter, options) {
     const className = options.className || (options.modelScope || Model).get(modelId)?._class;
     if (typeof className === 'undefined') {
       // Either the pointer is loaded as an object or we allow passing in the className.
-      return options.error('Must the pointer or include className');
+      return options.error('Must preload the Pointer or include className');
     }
 
     res['$relatedTo'] = {

--- a/packages/noodl-runtime/src/api/queryutils.js
+++ b/packages/noodl-runtime/src/api/queryutils.js
@@ -36,16 +36,15 @@ function convertVisualFilter(query, options) {
     const _res = {};
     var cond;
     var value = query.input !== undefined ? inputs[query.input] : query.value;
-    
+
     if (query.operator === 'exist') {
-        _res[query.property] = { $exists: true };
-        return _res;
+      _res[query.property] = { $exists: true };
+      return _res;
+    } else if (query.operator === 'not exist') {
+      _res[query.property] = { $exists: false };
+      return _res;
     }
-    else if (query.operator === 'not exist') {
-        _res[query.property] = { $exists: false };
-        return _res;
-    }
-    
+
     if (value === undefined) return;
 
     if (CloudStore._collections[options.collectionName])
@@ -79,7 +78,6 @@ function convertVisualFilter(query, options) {
     } else if (query.operator === 'contain') {
       cond = { $regex: value, $options: 'i' };
     }
-
 
     _res[query.property] = cond;
 
@@ -163,10 +161,23 @@ function _value(v) {
   return v;
 }
 
+/**
+ *
+ * @param {Record<string, unknown>} filter
+ * @param {{
+ *   className?: string;
+ *   collectionName?: string;
+ *   modelScope?: unknown;
+ *   error: (error: string) => void;
+ * }} options
+ * @returns
+ */
 function convertFilterOp(filter, options) {
   const keys = Object.keys(filter);
   if (keys.length === 0) return {};
-  if (keys.length !== 1) return options.error('Filter must only have one key found ' + keys.join(','));
+  if (keys.length !== 1) {
+    return options.error('Filter must only have one key found ' + keys.join(','));
+  }
 
   const res = {};
   const key = keys[0];
@@ -179,18 +190,27 @@ function convertFilterOp(filter, options) {
   } else if (filter['idContainedIn'] !== undefined) {
     res['objectId'] = { $in: filter['idContainedIn'] };
   } else if (filter['relatedTo'] !== undefined) {
-    var modelId = filter['relatedTo']['id'];
-    if (modelId === undefined) return options.error('Must provide id in relatedTo filter');
+    const modelId = filter['relatedTo']['id'];
+    if (modelId === undefined) {
+      return options.error('Must provide id in relatedTo filter');
+    }
 
-    var relationKey = filter['relatedTo']['key'];
-    if (relationKey === undefined) return options.error('Must provide key in relatedTo filter');
+    const relationKey = filter['relatedTo']['key'];
+    if (relationKey === undefined) {
+      return options.error('Must provide key in relatedTo filter');
+    }
 
-    var m = (options.modelScope || Model).get(modelId);
+    const className = options.className || (options.modelScope || Model).get(modelId)?._class;
+    if (typeof className === 'undefined') {
+      // Either the pointer is loaded as an object or we allow passing in the className.
+      return options.error('Must the pointer or include className');
+    }
+
     res['$relatedTo'] = {
       object: {
         __type: 'Pointer',
         objectId: modelId,
-        className: m._class
+        className
       },
       key: relationKey
     };
@@ -208,13 +228,14 @@ function convertFilterOp(filter, options) {
     else if (opAndValue['containedIn'] !== undefined) res[key] = { $in: opAndValue['containedIn'] };
     else if (opAndValue['notContainedIn'] !== undefined) res[key] = { $nin: opAndValue['notContainedIn'] };
     else if (opAndValue['pointsTo'] !== undefined) {
-      var m = (options.modelScope || Model).get(opAndValue['pointsTo']);
-      if (CloudStore._collections[options.collectionName])
-        var schema = CloudStore._collections[options.collectionName].schema;
+      let schema = null;
+      if (CloudStore._collections[options.collectionName]) {
+        schema = CloudStore._collections[options.collectionName].schema;
+      }
 
-      var targetClass =
+      const targetClass =
         schema && schema.properties && schema.properties[key] ? schema.properties[key].targetClass : undefined;
-      var type = schema && schema.properties && schema.properties[key] ? schema.properties[key].type : undefined;
+      const type = schema && schema.properties && schema.properties[key] ? schema.properties[key].type : undefined;
 
       if (type === 'Relation') {
         res[key] = {
@@ -223,13 +244,13 @@ function convertFilterOp(filter, options) {
           className: targetClass
         };
       } else {
-        if (Array.isArray(opAndValue['pointsTo']))
+        if (Array.isArray(opAndValue['pointsTo'])) {
           res[key] = {
             $in: opAndValue['pointsTo'].map((v) => {
               return { __type: 'Pointer', objectId: v, className: targetClass };
             })
           };
-        else
+        } else {
           res[key] = {
             $eq: {
               __type: 'Pointer',
@@ -237,6 +258,7 @@ function convertFilterOp(filter, options) {
               className: targetClass
             }
           };
+        }
       }
     } else if (opAndValue['matchesRegex'] !== undefined) {
       res[key] = {
@@ -257,43 +279,42 @@ function convertFilterOp(filter, options) {
             }
           }
         };
-    // Geo points
+      // Geo points
     } else if (opAndValue['nearSphere'] !== undefined) {
       var _v = opAndValue['nearSphere'];
       res[key] = {
         $nearSphere: {
-          __type: "GeoPoint",
+          __type: 'GeoPoint',
           latitude: _v.latitude,
-          longitude: _v.longitude,
+          longitude: _v.longitude
         },
-        $maxDistanceInMiles:_v.$maxDistanceInMiles,
-        $maxDistanceInKilometers:_v.maxDistanceInKilometers,
-        $maxDistanceInRadians:_v.maxDistanceInRadians
+        $maxDistanceInMiles: _v.$maxDistanceInMiles,
+        $maxDistanceInKilometers: _v.maxDistanceInKilometers,
+        $maxDistanceInRadians: _v.maxDistanceInRadians
       };
     } else if (opAndValue['withinBox'] !== undefined) {
       var _v = opAndValue['withinBox'];
       res[key] = {
-        $within:{
-          $box: _v.map(gp => ({
-            __type:"GeoPoint",
-            latitude:gp.latitude,
-            longitude:gp.longitude
+        $within: {
+          $box: _v.map((gp) => ({
+            __type: 'GeoPoint',
+            latitude: gp.latitude,
+            longitude: gp.longitude
           }))
         }
       };
     } else if (opAndValue['withinPolygon'] !== undefined) {
       var _v = opAndValue['withinPolygon'];
       res[key] = {
-        $geoWithin:{
-          $polygon: _v.map(gp => ({
-            __type:"GeoPoint",
-            latitude:gp.latitude,
-            longitude:gp.longitude
+        $geoWithin: {
+          $polygon: _v.map((gp) => ({
+            __type: 'GeoPoint',
+            latitude: gp.latitude,
+            longitude: gp.longitude
           }))
         }
       };
     }
-
   } else {
     options.error('Unrecognized filter keys ' + keys.join(','));
   }

--- a/packages/noodl-runtime/src/api/queryutils.js
+++ b/packages/noodl-runtime/src/api/queryutils.js
@@ -165,7 +165,6 @@ function _value(v) {
  *
  * @param {Record<string, unknown>} filter
  * @param {{
- *   className?: string;
  *   collectionName?: string;
  *   modelScope?: unknown;
  *   error: (error: string) => void;
@@ -200,7 +199,7 @@ function convertFilterOp(filter, options) {
       return options.error('Must provide key in relatedTo filter');
     }
 
-    const className = options.className || (options.modelScope || Model).get(modelId)?._class;
+    const className = filter['relatedTo']['className'] || (options.modelScope || Model).get(modelId)?._class;
     if (typeof className === 'undefined') {
       // Either the pointer is loaded as an object or we allow passing in the className.
       return options.error('Must preload the Pointer or include className');


### PR DESCRIPTION
Also includes error handling when "className" is not found.

How it currently works is that the Pointer has to be loaded to be able to do a relatedTo query. With this change you can now include the "className" in the query, where there is no need to query the Pointer first.

Example:
```ts
Noodl.Records.query(
    "_User",
    { relatedTo: { id: role.id, key: "users", className: "_Role" } }
)
```
    