### PR TITLE
fix(runtime): Close Popup node with no actions causing error

### DIFF
--- a/packages/noodl-viewer-react/src/nodes/navigation/closepopup.js
+++ b/packages/noodl-viewer-react/src/nodes/navigation/closepopup.js
@@ -51,8 +51,9 @@ const ClosePopupNode = {
       }
     },
     close: function () {
-      if (this._internal.closeCallback)
+      if (this._internal.closeCallback) {
         this._internal.closeCallback(this._internal.closeAction, this._internal.resultValues);
+      }
     },
     closeActionTriggered: function (name) {
       this._internal.closeAction = name;

--- a/packages/noodl-viewer-react/src/nodes/navigation/showpopup.js
+++ b/packages/noodl-viewer-react/src/nodes/navigation/showpopup.js
@@ -53,15 +53,24 @@ const ShowPopupNode = {
 
       this.context.showPopup(this._internal.target, this._internal.popupParams, {
         senderNode: this.nodeScope.componentOwner,
+        /**
+         * @param {string | undefined} action
+         * @param {*} results
+         */
         onClosePopup: (action, results) => {
           this._internal.closeResults = results;
 
-          for (var key in results) {
-            if (this.hasOutput('closeResult-' + key)) this.flagOutputDirty('closeResult-' + key);
+          for (const key in results) {
+            if (this.hasOutput('closeResult-' + key)) {
+              this.flagOutputDirty('closeResult-' + key);
+            }
           }
 
-          if (!action) this.sendSignalOnOutput('Closed');
-          else this.sendSignalOnOutput(action);
+          if (!action) {
+            this.sendSignalOnOutput('Closed');
+          } else {
+            this.sendSignalOnOutput(action);
+          }
         }
       });
     },


### PR DESCRIPTION
TypeError: Cannot read properties of undefined (reading 'replace')
    at Object.onClosePopup (navigation.js:10:1)
    at EventEmitter.<anonymous> (nodecontext.js:491:1)
    at Object.onceWrapper (events.js:242:1)
    at EventEmitter.emit (events.js:153:1)
    at NoodlRuntime._doUpdate (noodl-runtime.js:338:1)