### PR TITLE
feat(runtime): 'Set Variable' node, add editor getInspectInfo

### DIFF
--- a/packages/noodl-viewer-react/src/nodes/std-library/data/setvariablenode.js
+++ b/packages/noodl-viewer-react/src/nodes/std-library/data/setvariablenode.js
@@ -1,11 +1,9 @@
 'use strict';
 
-const { Node } = require('@noodl/runtime');
-
 const Model = require('@noodl/runtime/src/model');
 const Collection = require('@noodl/runtime/src/collection');
 
-var SetVariableNodeDefinition = {
+const SetVariableNodeDefinition = {
   name: 'Set Variable',
   docs: 'https://docs.noodl.net/nodes/data/variable/set-variable',
   category: 'Data',
@@ -15,6 +13,13 @@ var SetVariableNodeDefinition = {
     var internal = this._internal;
 
     internal.variablesModel = Model.get('--ndl--global-variables');
+  },
+  getInspectInfo() {
+    if (this._internal.name) {
+      return this._internal.variablesModel.get(this._internal.name);
+    }
+
+    return '[No value set]';
   },
   outputs: {
     done: {


### PR DESCRIPTION
It is very nice to be able to inspect the value inside the variable even via the "Set Variable" node. Most of the time I see an additional variable node placed above the "Set Variable" node to just inspect the current value.