### PR TITLE
Expand Address Bar on wide screens, keep error box small

### DIFF
--- a/packages/noodl-editor/src/editor/src/views/EditorTopbar/EditorTopbar.module.scss
+++ b/packages/noodl-editor/src/editor/src/views/EditorTopbar/EditorTopbar.module.scss
@@ -22,6 +22,9 @@
 
 .LeftSide {
   flex-grow: 1;
+  width: 100%;
+  display: flex;
+  align-items: stretch;
 }
 
 .is-padded-s {
@@ -51,7 +54,7 @@
 .UrlBarWrapper {
   flex-grow: 1;
   min-width: 150px;
-  max-width: 500px;
+  max-width: none;
   margin-right: -1px;
 }
 
@@ -108,4 +111,10 @@
     padding: 0 4px 0 8px;
     min-width: 0;
   }
+}
+
+.WarningsWrapper {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
 }

--- a/packages/noodl-editor/src/editor/src/views/EditorTopbar/EditorTopbar.module.scss
+++ b/packages/noodl-editor/src/editor/src/views/EditorTopbar/EditorTopbar.module.scss
@@ -22,9 +22,6 @@
 
 .LeftSide {
   flex-grow: 1;
-  width: 100%;
-  display: flex;
-  align-items: stretch;
 }
 
 .is-padded-s {
@@ -54,7 +51,6 @@
 .UrlBarWrapper {
   flex-grow: 1;
   min-width: 150px;
-  max-width: none;
   margin-right: -1px;
 }
 
@@ -111,10 +107,4 @@
     padding: 0 4px 0 8px;
     min-width: 0;
   }
-}
-
-.WarningsWrapper {
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
 }


### PR DESCRIPTION
Previously on widescreens, the error bar grows wide while the address bar has a max width. This wastes space because the error box never needs to grow that wide, while the URL bar in theory can be arbitrarily long. This small change reverses the logic so that the address bar takes up the maximum width possible.