### PR TITLE
feat: Save "nodelibrary.json" with the project

### DIFF
--- a/packages/noodl-editor/src/editor/src/models/nodelibrary/nodelibrary.ts
+++ b/packages/noodl-editor/src/editor/src/models/nodelibrary/nodelibrary.ts
@@ -1,9 +1,11 @@
 import _ from 'underscore';
+import { filesystem } from '@noodl/platform';
 
 import { ComponentModel } from '@noodl-models/componentmodel';
 import { NodeGraphNode } from '@noodl-models/nodegraphmodel';
 import { BasicNodeType } from '@noodl-models/nodelibrary/BasicNodeType';
 import { UnknownNodeType } from '@noodl-models/nodelibrary/UnknownNodeType';
+import { ProjectModel } from '@noodl-models/projectmodel';
 
 import Model from '../../../../shared/model';
 import { ModelProxy } from '../../views/panels/propertyeditor/models/modelProxy';

--- a/packages/noodl-editor/src/editor/src/models/projectmodel.ts
+++ b/packages/noodl-editor/src/editor/src/models/projectmodel.ts
@@ -1167,6 +1167,16 @@ EventDispatcher.instance.on(
   null
 );
 
+NodeLibrary.instance.on('libraryUpdated', () => {
+  const library = NodeLibrary.instance.library;
+  if (library) {
+    const filepath = filesystem.join(ProjectModel.instance._retainedProjectDirectory, 'nodelibrary.json');
+    filesystem.writeJson(filepath, library).then(() => {
+      console.log('saved nodelibrary.json');
+    });
+  }
+});
+
 function saveProject() {
   if (!ProjectModel.instance) return;
 

--- a/packages/noodl-editor/src/editor/src/utils/compilation/build/copy.ts
+++ b/packages/noodl-editor/src/editor/src/utils/compilation/build/copy.ts
@@ -4,7 +4,7 @@ import { clearFolders } from './cleanup';
 
 export async function copyProjectFilesToFolder(projectPath: string, direntry: string): Promise<void> {
   // TODO: Load something like .noodlignore file list
-  const ignoreFiles = ['.DS_Store', '.gitignore', '.gitattributes', 'project.json', 'Dockerfile'];
+  const ignoreFiles = ['.DS_Store', '.gitignore', '.gitattributes', 'project.json', 'Dockerfile', 'nodelibrary.json'];
 
   // Copy everything from the project folder
   if (!projectPath) {


### PR DESCRIPTION
To manage the project without the editor/preview, we need to know more about the Node Library. To make this possible, let's save the Node Library next to the project. Hopefully it will work smoothly for a lot of projects.

I have tested it with a few big projects, and it works well for them.